### PR TITLE
Use apt-mark to hold back grub-pc from updating

### DIFF
--- a/files/ServerSetup.sh
+++ b/files/ServerSetup.sh
@@ -10,6 +10,10 @@ fi
 function debian_initialize() {
     echo "Updating and Installing Dependicies"
     echo "deb http://ftp.debian.org/debian stretch-backports main" >> /etc/apt/sources.list
+    # If grub tries to update, then it brings up a curses UI and wants
+    # user input.  We can't deal with that here, and we don't actually
+    # need or want to update grub anyway, so just hold that package.
+    apt-mark hold grub-pc
     apt-get -qq update > /dev/null 2>&1
     echo "...keep waiting..."
     apt-get -qq -y upgrade > /dev/null 2>&1


### PR DESCRIPTION
If grub tries to update, then it brings up a curses UI and wants user input.  We can't deal with that here, and we don't actually need or want to update grub anyway.

This issue is biting the PCAers right now, since it is making some of their setup steps hang and or fail.