### PR TITLE
Modify code to always copy the "classic PCA" version of the server setup script

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,0 @@
----
-# defaults file for ansible-role-server-setup
-
-# If true, then the ServerSetup script in files is installed.
-# Otherwise the latest ServerSetup code from
-# https://github.com/noahpowers/ServerSetup is used.
-use_pca_script: false

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -18,7 +18,14 @@ def test_packages(host, pkg):
     assert host.package(pkg).is_installed
 
 
-@pytest.mark.parametrize("f", ["/opt/ServerSetup", "/opt/ServerSetup/serversetup.sh"])
+@pytest.mark.parametrize(
+    "f",
+    [
+        "/opt/ServerSetup",
+        "/opt/ServerSetup/serversetup.sh",
+        "/opt/ServerSetup/classic_pca_serversetup.sh",
+    ],
+)
 def test_files(host, f):
     """Test that the expected files and directories are present."""
     assert host.file(f).exists

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -23,6 +23,5 @@
 - name: Copy the PCA-specific ServerSetup script
   ansible.builtin.copy:
     src: pca_serversetup.sh
-    dest: /opt/ServerSetup/serversetup.sh
+    dest: /opt/ServerSetup/classic_pca_serversetup.sh
     mode: 0755
-  when: use_pca_script


### PR DESCRIPTION
## 🗣 Description ##

This pull request removes a role variable that determined whether the [upstream version](https://github.com/noahpowers/ServerSetup/blob/master/serversetup.sh) or the "classic PCA" version of the Server Setup script is installed; now, the classic version is _always_ copied to `/opt/ServerSetup/classic_pca_serversetup.sh`. 
(The upstream version remains at `/opt/ServerSetup/serversetup.sh`.)

## 💭 Motivation and context ##

The "classic PCA" version of the script is the one that the PCA folks have been using since antediluvian times.  Now that they are interested in moving to the COOL, I had set them up with an instance that contained the upstream version.  They found that they would have to make a lot of changes to their runbook in order to get that working, so now I will give them an AMI with both versions installed so that they can use the old one.

## 🧪 Testing ##

All `pre-commit` hooks and `molecule` tests pass.

## ✅ Checklist ##

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] Tests have been added and/or modified to cover the changes in this PR.
* [x] All new and existing tests pass.
